### PR TITLE
Update dependencies, drop clojure 1.3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ Tested against:
 
 Clojure versions:
 
-* Clojure 1.3
 * Clojure 1.4
 * Clojure 1.5
 * Clojure 1.6
+* Clojure 1.7
+* Clojure 1.8
 
 ##License
 (The MIT License)

--- a/project.clj
+++ b/project.clj
@@ -3,11 +3,11 @@
   :url "https://github.com/josephwilk/circuit-breaker"
   :license {:name "MIT"
             :url "https://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [clj-time "0.4.4"]
-                 [slingshot "0.10.3"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clj-time "0.11.0"]
+                 [slingshot "0.12.2"]]
 
-  :aliases {"compatibility" ["with-profile" "1.4:1.5" "test"]}
+  :aliases {"compatibility" ["with-profile" "1.4:1.5:1.6:1.7:1.8" "test"]}
 
   :profiles {:dev {:dependencies [[midje "1.4.0"]
                                   [bultitude "0.1.7"]]
@@ -15,8 +15,8 @@
                                   [lein-kibit "0.0.7"]
                                   [jonase/eastwood "0.0.2"]
                                   [lein-cloverage "1.0.2"]]}
-
-             :1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
-             :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
-             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}})
+             :1.4 [:dev {:dependencies [[org.clojure/clojure "1.4.0"]]}]
+             :1.5 [:dev {:dependencies [[org.clojure/clojure "1.5.0"]]}]
+             :1.6 [:dev {:dependencies [[org.clojure/clojure "1.6.0"]]}]
+             :1.7 [:dev {:dependencies [[org.clojure/clojure "1.7.0"]]}]
+             :1.8 [:dev {:dependencies [[org.clojure/clojure "1.8.0"]]}]})

--- a/src/circuit_breaker/core.clj
+++ b/src/circuit_breaker/core.clj
@@ -35,7 +35,7 @@
   (boolean (time-since-broken circuit-name)))
 
 (defn- timeout-exceeded? [circuit-name]
-  (> (time/in-secs (time/interval (time-since-broken circuit-name) (time/now))) (timeout-in-seconds circuit-name)))
+  (> (time/in-seconds (time/interval (time-since-broken circuit-name) (time/now))) (timeout-in-seconds circuit-name)))
 
 (defn record-failure! [circuit-name]
   (inc-counter circuit-name)


### PR DESCRIPTION
- Update dependencies to latest versions of clj-time and slingshot.
- Change use of `in-secs`, which has been deprecated, to `in-seconds`
- Make compatibility alias able to run tests (previously failed due to
  being unable to find midje)
- Drop clojure 1.3 compatibility (ex-info didn't exist until clojure
  1.4, meaning slingshot will only work with clojure 1.4+)
